### PR TITLE
fix: Switch to trust-manager new chart name

### DIFF
--- a/l5d-certificate-management/guided-tour.sh
+++ b/l5d-certificate-management/guided-tour.sh
@@ -518,7 +518,7 @@ pe "helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set ins
 
 show ""
 show "# Also install the JetStack 'trust' tool."
-pe "helm upgrade -i -n cert-manager cert-manager-trust jetstack/cert-manager-trust --wait"
+pe "helm upgrade -i -n cert-manager trust-manager jetstack/trust-manager --wait"
 wait
 
 clear


### PR DESCRIPTION
Small change to install the latest version of [trust-manager](https://github.com/cert-manager/trust-manager). 
The older chart name has been deprecated which can be checked using `helm search repo jetstack/`.

```
jetstack/cert-manager-trust            	v0.2.1       	v0.2.0     	DEPRECATED: The old name for trust-manager. Use...
jetstack/trust-manager                 	v0.5.0       	v0.5.0     	trust-manager is the easiest way to manage TLS ..
```

I double checked the install commands in order for Jetstack components:

```
(⎈|kind-test:default)➜  service-mesh-academy git:(pf/update-trust-manager) ✗ helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true --wait --create-namespace
Release "cert-manager" does not exist. Installing it now.
NAME: cert-manager
LAST DEPLOYED: Thu Jul 20 17:58:30 2023
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
cert-manager v1.12.2 has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://cert-manager.io/docs/configuration/

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://cert-manager.io/docs/usage/ingress/
(⎈|kind-test:default)➜  service-mesh-academy git:(pf/update-trust-manager) ✗ helm upgrade -i -n cert-manager trust-manager jetstack/trust-manager --wait
Release "trust-manager" does not exist. Installing it now.
NAME: trust-manager
LAST DEPLOYED: Thu Jul 20 17:59:32 2023
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
trust-manager v0.5.0 has been deployed successfully!
Your installation includes a default CA package, using the following
default CA package image:

quay.io/jetstack/cert-manager-package-debian:20210119.0

It's imperative that you keep the default CA package image up to date.
To find out more about securely running trust-manager and to get started
with creating your first bundle, check out the documentation on the
cert-manager website:

https://cert-manager.io/docs/projects/trust-manager/
```

I have not ran the full demo though.