### PR TITLE
eliminate-cross-zone-traffic-hazl updates

### DIFF
--- a/eliminate-cross-zone-traffic-hazl/README.md
+++ b/eliminate-cross-zone-traffic-hazl/README.md
@@ -868,7 +868,7 @@ The colors map to the warehouses as follows:
 - Blue: This is the Boston warehouse (`warehouse-boston`)
 - Green: This is the Chicago warehouse (`warehouse-chicago`)
 
-Change the value of `averageResponseTime` under `green.yml` from `0.020` to `0.120`. Save and exit.
+Change the value of `averageResponseTime` under `green.yml` from `0.020` to `0.920`. Save and exit.
 
 We need to restart the `warehouse-chicago` deployment to pick up the changes:
 


### PR DESCRIPTION
Increased the latency value for warehouse-chicago, due to tighter load bands in 2.15.2.